### PR TITLE
Various improvements to shell scripts

### DIFF
--- a/scripts/create_makefile.sh
+++ b/scripts/create_makefile.sh
@@ -38,11 +38,22 @@ echo -e "CFLAGS = "${cflags[@]}"\n" >> Makefile
 
 echo "[*] Adding predefined rules..."
 
-echo -e "all: leaguedisplays assets\n" >> Makefile
-echo -e "leaguedisplays: bin/leaguedisplays\n" >> Makefile
-echo -e "clean: clean-assets\n\trm *.o\n\trm ./bin/leaguedisplays\n" >> Makefile
-echo -e "strip:\n\tstrip ./bin/leaguedisplays\n" >> Makefile
-echo -e "leaguedisplays_version.h: ./scripts/create_version.sh\n\t./scripts/create_version.sh\n" >> Makefile
+echo -e >> Makefile "
+all: leaguedisplays assets
+
+leaguedisplays: bin/leaguedisplays
+
+clean: clean-assets
+\trm -f *.o
+\trm -f ./bin/leaguedisplays
+
+strip:
+\tstrip ./bin/leaguedisplays
+
+leaguedisplays_version.h: ./scripts/create_version.sh
+\t./scripts/create_version.sh
+
+"
 
 echo "[*] Creating rules for assets..."
 
@@ -91,15 +102,15 @@ echo "[*] Creating rules for source files..."
 sources=($(find src | grep --regex="\.cc$"))
 objects=()
 
-for f in ${sources[@]}; do
+for f in "${sources[@]}"; do
 	object=$(echo $f | sed -r 's/\.cc$/\.o/g' | sed -r 's/src\///g')
 	objects+=("$object")
 
 	rule_header="$object: "
 	rule_header+="$f "
 
-	includes=($(cat $f | grep -oP --regex="#include.*?\".*?\"" | sed -r 's/#include\s+//g' | cut -c 2- | sed -r 's/\"$//g'))
-	for i in ${includes[@]}; do
+	includes=($(cat "$f" | grep -oP --regex="#include.*?\".*?\"" | sed -r 's/#include\s+//g' | cut -c 2- | sed -r 's/\"$//g'))
+	for i in "${includes[@]}"; do
 		if [[ ! $i =~ ^"include/" ]]; then
 			if [[ -f "src/$i" ]]; then
 				i="src/$i"
@@ -109,7 +120,7 @@ for f in ${sources[@]}; do
 		fi
 	done
 
-	echo $rule_header >> Makefile
+	echo "$rule_header" >> Makefile
 	echo -e "\t\$(CXX) \$(CFLAGS) -c $f\n" >> Makefile
 done
 
@@ -117,5 +128,7 @@ objects+=("./thirdparty/cef/libcef_dll_wrapper/libcef_dll_wrapper.a")
 
 echo "[*] Adding linker rule..."
 
-echo "bin/leaguedisplays: "${objects[@]} >> Makefile
-echo -e "\t\$(CXX) \$(CFLAGS) -o ./bin/leaguedisplays "${objects[@]} >> Makefile
+echo -e >> Makefile "
+bin/leaguedisplays: ${objects[@]}
+\t\$(CXX) \$(CFLAGS) -o ./bin/leaguedisplays ${objects[@]}
+"

--- a/scripts/create_version.sh
+++ b/scripts/create_version.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
 
-echo -e "// AUTOMATICALLY GENERATED FILE! DO NOT EDIT!\n" > leaguedisplays_version.h
-echo "#ifndef LD_VERSION_H" >> leaguedisplays_version.h
-echo -e "#define LD_VERSION_H\n" >> leaguedisplays_version.h
+branch=$(git branch --no-color 2> /dev/null | sed -e '/^[^*]/d' -e "s/* \(.*\)/\1/")
+version=$(git rev-parse --short HEAD 2> /dev/null | sed "s/\(.*\)/\1/")
 
-echo -en "#define LD_APPVERSION \"L1.0.928-beta_x86_64-" >> leaguedisplays_version.h
-printf "%s" $(git branch --no-color 2> /dev/null | sed -e '/^[^*]/d' -e "s/* \(.*\)/\1/") >> leaguedisplays_version.h
-echo -n "/" >> leaguedisplays_version.h
-printf "%s" $(git rev-parse --short HEAD 2> /dev/null | sed "s/\(.*\)/\1/") >> leaguedisplays_version.h
-echo -en "\"\n\n#endif // LD_VERSION_H" >> leaguedisplays_version.h
+echo -e >> leaguedisplays_version.h "
+// AUTOMATICALLY GENERATED FILE! DO NOT EDIT!
+#ifndef LD_VERSION_H
+#define LD_VERSION_H
+
+#define LD_APPVERSION \"L1.0.928-beta_x86_64-${branch}/${version}\"
+#endif // LD_VERSION_H
+"


### PR DESCRIPTION
Note: not fully tested as I don't have a Linux environment with required dependencies at hand.
Feel free to adapt. ;)

- Use positive values as exit codes (on Linux, negative values are used
  for processes ended by a signal).
- Fix quoting.
- Use `getopt` to parse options
- Use `$PWD` instead of `$(pwd)`.
- Remove commented code.
- Remove useless `mkdir -p $PWD/thirdparty`, already created by `mkdir -p $PWD/thirdparty/cef`
- Use `$(...)` over backquotes
- Use multi-line echo when relevant (for clarity).
- Add -h,--help option
- Don't popd in case of assert_success failure: the stack may be empty
  and restoring cwd is not needed as the process will exit.